### PR TITLE
feat: resolve match save players by telegram id

### DIFF
--- a/.cursor/test-scenario-user-id-resolution.md
+++ b/.cursor/test-scenario-user-id-resolution.md
@@ -1,0 +1,114 @@
+# Test Scenario: User ID Resolution for Match Save
+
+## Problem Fixed
+Previously, `resolvePlayer()` used partial name matching, causing "Nghia2" to match the registered player "Nghia". Now resolution uses:
+1. **Telegram user_id** (when available) - Most stable
+2. **Exact name match** (fallback) - Only when name exactly matches
+
+## Resolution Priority
+
+### Identifier Stability Ranking (Best → Worst)
+1. **`user_id` (Telegram ID)** ✅ Most Stable
+   - Assigned by Telegram, never changes
+   - Persists even if user changes display name or username
+   - Only available for entries added via `/addme`
+
+2. **`number` (Shirt Number)** ⚠️ Less Stable
+   - Can change if player updates their registration
+   - Used for stats commands (`/match goal 10 2`)
+
+3. **`name`** ❌ Least Stable
+   - User can change first_name in Telegram anytime
+   - Used as fallback only
+
+## Flow Examples
+
+### Case 1: You use /addme (has userId)
+```
+1. /addme
+   → members.set(123456789, { name: "Nghia (@user)", userId: 123456789 })
+   
+2. /register 10
+   → DB: players { id: 1, user_id: 123456789, number: 10, name: "Nghia" }
+   
+3. /addtoteam HOME 1
+   → teamA.set(fakeId, { name: "Nghia (@user)", userId: 123456789 })
+   
+4. /match SAVE
+   → resolvePlayer({ name: "Nghia (@user)", userId: 123456789 }, allPlayers)
+   → getPlayerByUserId(123456789) → finds player with id: 1 ✅
+   → Result: { playerId: 1, displayName: "Nghia (@user)" }
+   → Saved to match_players with player_id = 1
+```
+
+### Case 2: Someone else uses /add "Nghia2" (no userId)
+```
+1. /add Nghia2
+   → members.set(fakeId, { name: "Nghia2" })  // no userId
+   
+2. /addtoteam HOME 1
+   → teamA.set(fakeId, { name: "Nghia2" })  // no userId
+   
+3. /match SAVE
+   → resolvePlayer({ name: "Nghia2" }, allPlayers)
+   → getUserId() → undefined, skip user_id lookup
+   → Exact name check: "nghia2" === "nghia" ? NO ❌
+   → Result: { playerId: null, displayName: "Nghia2" }
+   → Saved to match_players with player_id = NULL, display_name = "Nghia2"
+```
+
+### Case 3: Exact name match (without userId)
+```
+1. /add Nghia
+   → members.set(fakeId, { name: "Nghia" })  // no userId
+   
+2. /addtoteam HOME 1
+   → teamA.set(fakeId, { name: "Nghia" })
+   
+3. /match SAVE
+   → resolvePlayer({ name: "Nghia" }, allPlayers)
+   → getUserId() → undefined
+   → Exact name check: "nghia" === "nghia" ? YES ✅
+   → Result: { playerId: 1, displayName: "Nghia" }
+   → Saved to match_players with player_id = 1
+```
+
+## Expected Behavior After Fix
+
+### Scenario from User
+1. User with name "Nghia" does `/addme`
+   - Stored as `{ name: "Nghia (@user)", userId: 123456789 }`
+   
+2. Same user does `/add Nghia2`
+   - Stored as `{ name: "Nghia2" }` (no userId, different name)
+   
+3. Both added to team and saved via `/match SAVE`
+   - **"Nghia (@user)"**: Resolved by `user_id` → linked to registered player
+   - **"Nghia2"**: No userId, no exact match → stays as display-only (different player)
+   
+✅ Result: Two separate entries in match lineup, no duplicate counting
+
+## Code Changes Summary
+
+1. **`src/utils/team-member.js`** (NEW)
+   - `toEntry(name, userId?)` - Creates entry with optional userId
+   - `getDisplayName(value)` - Extracts display name
+   - `getUserId(value)` - Extracts userId if present
+
+2. **`src/commands/add/add-me.js`**
+   - Changed: `members.set(userId, toEntry(name, userId))`
+   - Stores userId so it can be used for resolution
+
+3. **`src/commands/add/add.js`**
+   - Changed: `members.set(fakeId, toEntry(name))`
+   - No userId (manually added names)
+
+4. **`src/commands/match/match.js`**
+   - `resolvePlayer()` now async, checks `getPlayerByUserId(userId)` first
+   - Falls back to exact name match only
+   - Removed partial matching (was causing bug)
+   - `buildPlayerEntries()` now returns Promise
+
+5. **All team management commands**
+   - Updated to use `getDisplayName()` helper
+   - Carry full entry `{ name, userId? }` through the flow

--- a/src/commands/add/add-me.js
+++ b/src/commands/add/add-me.js
@@ -1,4 +1,5 @@
 const { isValidName, isDuplicateName } = require('../../utils/validate');
+const { toEntry, getDisplayName } = require('../../utils/team-member');
 const { ADD_ME } = require('../../utils/messages');
 const { PATTERNS } = require('../../utils/constants');
 const { sendMessage } = require('../../utils/chat');
@@ -21,7 +22,7 @@ const addMeCommand = ({ members }) => {
       return;
     }
 
-    const allNames = Array.from(members.values());
+    const allNames = Array.from(members.values()).map(getDisplayName);
     if (isDuplicateName(msg.from.first_name, allNames)) {
       sendMessage({
         msg,
@@ -31,7 +32,7 @@ const addMeCommand = ({ members }) => {
       return;
     }
 
-    members.set(userId, name);
+    members.set(userId, toEntry(name, userId));
     sendMessage({
       msg,
       type: 'MAIN',

--- a/src/commands/add/add.js
+++ b/src/commands/add/add.js
@@ -1,4 +1,5 @@
 const { isValidName, isDuplicateName } = require('../../utils/validate');
+const { toEntry, getDisplayName } = require('../../utils/team-member');
 const { ADD } = require('../../utils/messages');
 const { PATTERNS } = require('../../utils/constants');
 
@@ -36,7 +37,7 @@ const addCommand = ({ members }) => {
       return;
     }
 
-    const allNames = Array.from(members.values());
+    const allNames = Array.from(members.values()).map(getDisplayName);
     let addedCount = 0;
     const invalidNames = [];
 
@@ -47,7 +48,7 @@ const addCommand = ({ members }) => {
       }
       if (!isDuplicateName(name, allNames)) {
         const fakeId = Date.now() + Math.random();
-        members.set(fakeId, name);
+        members.set(fakeId, toEntry(name));
         allNames.push(name);
         addedCount++;
       }

--- a/src/commands/bench/bench.js
+++ b/src/commands/bench/bench.js
@@ -1,3 +1,4 @@
+const { getDisplayName } = require('../../utils/team-member');
 const { BENCH } = require('../../utils/messages');
 const { sendMessage } = require('../../utils/chat');
 
@@ -13,7 +14,7 @@ const benchCommand = ({ members }) => {
       });
       return;
     }
-    const names = Array.from(members.values());
+    const names = Array.from(members.values()).map(getDisplayName);
 
     sendMessage({
       msg,

--- a/src/commands/bench/clear-bench.js
+++ b/src/commands/bench/clear-bench.js
@@ -1,3 +1,4 @@
+const { getDisplayName } = require('../../utils/team-member');
 const { CLEAR_BENCH, VALIDATION } = require('../../utils/messages');
 const { sendMessage } = require('../../utils/chat');
 const { requireAdmin } = require('../../utils/permissions');
@@ -6,7 +7,8 @@ const bot = require('../../bot');
 
 const clearBenchCommand = ({ members }) => {
   bot.onText(/^\/clearbench$/, msg => {
-    const allNames = Array.from(members.values());
+    const allEntries = Array.from(members.entries());
+    const allNames = allEntries.map(([, v]) => getDisplayName(v));
 
     if (allNames.length === 0) {
       sendMessage({
@@ -50,7 +52,8 @@ const clearBenchCommand = ({ members }) => {
     }
 
     const selection = match[1].trim();
-    const allNames = Array.from(members.values());
+    const allEntries = Array.from(members.entries());
+    const allNames = allEntries.map(([, v]) => getDisplayName(v));
 
     // Handle clear all
     if (selection.toLowerCase() === 'all') {
@@ -111,18 +114,9 @@ const clearBenchCommand = ({ members }) => {
 
     // Remove selected members from bench
     selectedIndices.sort((a, b) => b - a);
-    const removedNames = [];
-    for (const index of selectedIndices) {
-      const name = allNames[index];
-      for (const [userId, memberName] of members) {
-        const nameOnly = memberName.split(' (')[0].trim();
-        if (nameOnly === name.split(' (')[0].trim()) {
-          members.delete(userId);
-          removedNames.push(name);
-          break;
-        }
-      }
-    }
+    const selectedEntries = selectedIndices.map(i => allEntries[i]);
+    selectedEntries.forEach(([key]) => members.delete(key));
+    const removedNames = selectedEntries.map(([, v]) => getDisplayName(v));
 
     if (removedNames.length === 0) {
       const noRemoved = CLEAR_BENCH.noRemovedMembers;

--- a/src/commands/match/match.js
+++ b/src/commands/match/match.js
@@ -12,7 +12,12 @@ const {
   setMatchMvp,
   isPlayerInMatch,
 } = require('../../api/matches');
-const { getAllPlayers, getPlayerByNumber } = require('../../api/players');
+const {
+  getAllPlayers,
+  getPlayerByNumber,
+  getPlayerByUserId,
+} = require('../../api/players');
+const { getDisplayName, getUserId } = require('../../utils/team-member');
 const sanCommand = require('../management/san');
 
 const bot = require('../../bot');
@@ -57,39 +62,45 @@ function parseDate(str) {
 }
 
 /**
- * Resolve display name to player. Returns { playerId, displayName }.
- * @param {string} displayName
- * @param {Array} allPlayers
- * @returns {{ playerId: number|null, displayName: string }}
+ * Resolve a team entry to a registered player. Uses user_id (Telegram ID) when
+ * available (most stable); otherwise falls back to exact name match.
+ * Entries from /addme carry userId; from /add they do not.
+ *
+ * @param {string|{ name: string, userId?: number }} entry - value from team Map
+ * @param {Array} allPlayers - from getAllPlayers() (registered only)
+ * @returns {Promise<{ playerId: number|null, displayName: string }>}
  */
-function resolvePlayer(displayName, allPlayers) {
+async function resolvePlayer(entry, allPlayers) {
+  const displayName = getDisplayName(entry);
+  const userId = getUserId(entry);
+
+  if (userId != null) {
+    const player = await getPlayerByUserId(userId);
+    if (player) return { playerId: player.id, displayName };
+  }
+
   const baseName = displayName.split(' (')[0].trim();
   const exact = allPlayers.find(
     p => p.name.toLowerCase() === baseName.toLowerCase()
   );
   if (exact) return { playerId: exact.id, displayName };
-  const partial = allPlayers.find(
-    p =>
-      p.name.toLowerCase().includes(baseName.toLowerCase()) ||
-      baseName.toLowerCase().includes(p.name.toLowerCase())
-  );
-  if (partial) return { playerId: partial.id, displayName };
   return { playerId: null, displayName };
 }
 
 /**
- * Build home/away player entries from team Maps.
+ * Build home/away player entries from team Maps (supports entry shape { name, userId? }).
+ *
  * @param {Map} teamA
  * @param {Map} teamB
  * @param {Array} allPlayers
- * @returns {{ homePlayers: Array, awayPlayers: Array }}
+ * @returns {Promise<{{ homePlayers: Array, awayPlayers: Array }}>}
  */
-function buildPlayerEntries(teamA, teamB, allPlayers) {
-  const homePlayers = Array.from(teamA.values()).map(name =>
-    resolvePlayer(name, allPlayers)
+async function buildPlayerEntries(teamA, teamB, allPlayers) {
+  const homePlayers = await Promise.all(
+    Array.from(teamA.values()).map(entry => resolvePlayer(entry, allPlayers))
   );
-  const awayPlayers = Array.from(teamB.values()).map(name =>
-    resolvePlayer(name, allPlayers)
+  const awayPlayers = await Promise.all(
+    Array.from(teamB.values()).map(entry => resolvePlayer(entry, allPlayers))
   );
   return { homePlayers, awayPlayers };
 }
@@ -297,7 +308,7 @@ function matchCommand({ getTiensan, teamA, teamB }) {
 
       try {
         const allPlayers = await getAllPlayers();
-        const { homePlayers, awayPlayers } = buildPlayerEntries(
+        const { homePlayers, awayPlayers } = await buildPlayerEntries(
           teamA,
           teamB,
           allPlayers

--- a/src/commands/team/add-to-team.js
+++ b/src/commands/team/add-to-team.js
@@ -1,3 +1,4 @@
+const { getDisplayName } = require('../../utils/team-member');
 const { ADD_TO_TEAM } = require('../../utils/messages');
 const { sendMessage } = require('../../utils/chat');
 
@@ -7,7 +8,8 @@ const addToTeamCommand = ({ members, teamA, teamB }) => {
   bot.onText(/^\/addtoteam (HOME|AWAY)$/, (msg, match) => {
     const teamType = match[1];
     const teamName = teamType === 'HOME' ? 'Home' : 'Away';
-    const allNames = Array.from(members.values());
+    const allEntries = Array.from(members.entries());
+    const allNames = allEntries.map(([, v]) => getDisplayName(v));
 
     if (allNames.length === 0) {
       sendMessage({
@@ -41,7 +43,8 @@ const addToTeamCommand = ({ members, teamA, teamB }) => {
     const selection = match[2].trim();
     const team = teamType === 'HOME' ? teamA : teamB;
     const teamName = teamType === 'HOME' ? 'Home' : 'Away';
-    const allNames = Array.from(members.values());
+    const allEntries = Array.from(members.entries());
+    const allNames = allEntries.map(([, v]) => getDisplayName(v));
 
     if (allNames.length === 0) {
       sendMessage({
@@ -113,30 +116,23 @@ const addToTeamCommand = ({ members, teamA, teamB }) => {
     }
 
     selectedIndices = [...new Set(selectedIndices)].sort((a, b) => a - b);
-    const selectedNames = selectedIndices.map(index => allNames[index]);
+    const selectedEntries = selectedIndices.map(i => allEntries[i]);
 
-    // Remove selected members from main list
-    selectedNames.forEach(name => {
-      for (const [userId, memberName] of members) {
-        const nameOnly = memberName.split(' (')[0].trim();
-        if (nameOnly === name.split(' (')[0].trim()) {
-          members.delete(userId);
-          break;
-        }
-      }
-    });
-
-    // Add to selected team
-    selectedNames.forEach((name, idx) => {
+    // Remove selected members from main list and add to team (carry name + userId)
+    selectedEntries.forEach(([key]) => members.delete(key));
+    selectedEntries.forEach(([, entry], idx) => {
       const fakeId = Date.now() + Math.random() + idx;
-      team.set(fakeId, name);
+      team.set(fakeId, entry);
     });
+
+    const selectedNames = selectedEntries.map(([, v]) => getDisplayName(v));
+    const teamMemberDisplays = Array.from(team.values()).map(getDisplayName);
 
     const message = ADD_TO_TEAM.success
       .replace('{count}', selectedNames.length)
       .replaceAll('{team}', teamName)
       .replace('{selectedNames}', selectedNames.join('\n'))
-      .replace('{teamMembers}', Array.from(team.values()).join('\n'));
+      .replace('{teamMembers}', teamMemberDisplays.join('\n'));
 
     sendMessage({
       msg,

--- a/src/commands/team/chia-team.js
+++ b/src/commands/team/chia-team.js
@@ -1,4 +1,5 @@
 const shuffleArray = require('../../utils/shuffle');
+const { getDisplayName } = require('../../utils/team-member');
 const { sendMessage } = require('../../utils/chat');
 
 const bot = require('../../bot');
@@ -24,15 +25,15 @@ const splitCommand = ({ members, teamA, teamB }) => {
         return;
       }
 
-      const newNames = Array.from(members.values());
-      shuffleArray(newNames);
+      const newEntries = Array.from(members.values());
+      shuffleArray(newEntries);
 
-      newNames.forEach((name, index) => {
+      newEntries.forEach((entry, index) => {
         const fakeId = Date.now() + Math.random() + index;
         if (teamA.size <= teamB.size) {
-          teamA.set(fakeId, name);
+          teamA.set(fakeId, entry);
         } else {
-          teamB.set(fakeId, name);
+          teamB.set(fakeId, entry);
         }
       });
 
@@ -40,7 +41,11 @@ const splitCommand = ({ members, teamA, teamB }) => {
 
       const message = `🎲 *Thêm member mới vào team* 🎲\n\n👤 *Team A:*\n${Array.from(
         teamA.values()
-      ).join('\n')}\n\n👤 *Team B:*\n${Array.from(teamB.values()).join('\n')}`;
+      )
+        .map(getDisplayName)
+        .join('\n')}\n\n👤 *Team B:*\n${Array.from(teamB.values())
+        .map(getDisplayName)
+        .join('\n')}`;
 
       sendMessage({
         msg,
@@ -53,26 +58,28 @@ const splitCommand = ({ members, teamA, teamB }) => {
       return;
     }
 
-    const names = Array.from(members.values());
-    shuffleArray(names);
+    const entries = Array.from(members.values());
+    shuffleArray(entries);
 
-    const half = Math.ceil(names.length / 2);
+    const half = Math.ceil(entries.length / 2);
     teamA.clear();
     teamB.clear();
-    names.slice(0, half).forEach((name, idx) => {
+    entries.slice(0, half).forEach((entry, idx) => {
       const fakeId = Date.now() + Math.random() + idx;
-      teamA.set(fakeId, name);
+      teamA.set(fakeId, entry);
     });
-    names.slice(half).forEach((name, idx) => {
+    entries.slice(half).forEach((entry, idx) => {
       const fakeId = Date.now() + Math.random() + half + idx;
-      teamB.set(fakeId, name);
+      teamB.set(fakeId, entry);
     });
 
     members.clear();
 
-    const message = `🎲 *Chia team* 🎲\n\n👤 *HOME:*\n${Array.from(
-      teamA.values()
-    ).join('\n')}\n\n👤 *AWAY:*\n${Array.from(teamB.values()).join('\n')}`;
+    const message = `🎲 *Chia team* 🎲\n\n👤 *HOME:*\n${Array.from(teamA.values())
+      .map(getDisplayName)
+      .join('\n')}\n\n👤 *AWAY:*\n${Array.from(teamB.values())
+      .map(getDisplayName)
+      .join('\n')}`;
 
     sendMessage({
       msg,

--- a/src/commands/team/clear-team.js
+++ b/src/commands/team/clear-team.js
@@ -3,6 +3,7 @@ const {
   CLEAR_TEAM_INDIVIDUAL,
   VALIDATION,
 } = require('../../utils/messages');
+const { getDisplayName } = require('../../utils/team-member');
 const { sendMessage } = require('../../utils/chat');
 const { requireAdmin } = require('../../utils/permissions');
 
@@ -23,13 +24,10 @@ const clearTeamCommand = ({ teamA, teamB, members }) => {
       return;
     }
 
-    const allTeamMembers = [...teamA.values(), ...teamB.values()];
-    let restoredCount = 0;
-
-    allTeamMembers.forEach((name, index) => {
+    const allTeamEntries = [...teamA.values(), ...teamB.values()];
+    allTeamEntries.forEach((entry, index) => {
       const fakeId = Date.now() + Math.random() + index;
-      members.set(fakeId, name);
-      restoredCount++;
+      members.set(fakeId, entry);
     });
 
     teamA.clear();
@@ -50,7 +48,8 @@ const clearTeamCommand = ({ teamA, teamB, members }) => {
     const teamType = match[1];
     const team = teamType === 'HOME' ? teamA : teamB;
     const teamName = teamType === 'HOME' ? 'Home' : 'Away';
-    const teamANames = Array.from(team.values());
+    const teamEntries = Array.from(team.entries());
+    const teamANames = teamEntries.map(([, v]) => getDisplayName(v));
 
     if (teamANames.length === 0) {
       sendMessage({
@@ -85,7 +84,8 @@ const clearTeamCommand = ({ teamA, teamB, members }) => {
     const selection = match[2].trim();
     const team = teamType === 'HOME' ? teamA : teamB;
     const teamName = teamType === 'HOME' ? 'Home' : 'Away';
-    const teamANames = Array.from(team.values());
+    const teamEntries = Array.from(team.entries());
+    const teamANames = teamEntries.map(([, v]) => getDisplayName(v));
 
     if (teamANames.length === 0) {
       sendMessage({
@@ -160,20 +160,10 @@ const clearTeamCommand = ({ teamA, teamB, members }) => {
     }
 
     selectedIndices = [...new Set(selectedIndices)].sort((a, b) => b - a);
-    const resetNames = [];
+    const selectedEntries = selectedIndices.map(i => teamEntries[i]);
 
-    for (const index of selectedIndices) {
-      const name = teamANames[index];
-
-      for (const [userId, memberName] of team) {
-        const nameOnly = memberName.split(' (')[0].trim();
-        if (nameOnly === name.split(' (')[0].trim()) {
-          team.delete(userId);
-          resetNames.push(name);
-          break;
-        }
-      }
-    }
+    selectedEntries.forEach(([key]) => team.delete(key));
+    const resetNames = selectedEntries.map(([, v]) => getDisplayName(v));
 
     if (resetNames.length === 0) {
       sendMessage({
@@ -184,11 +174,9 @@ const clearTeamCommand = ({ teamA, teamB, members }) => {
       return;
     }
 
-    let addedCount = 0;
-    resetNames.forEach(name => {
-      const fakeId = Date.now() + Math.random() + addedCount;
-      members.set(fakeId, name);
-      addedCount++;
+    selectedEntries.forEach((entry, idx) => {
+      const fakeId = Date.now() + Math.random() + idx;
+      members.set(fakeId, entry);
     });
 
     const message = CLEAR_TEAM_INDIVIDUAL.success

--- a/src/commands/team/team.js
+++ b/src/commands/team/team.js
@@ -1,3 +1,4 @@
+const { getDisplayName } = require('../../utils/team-member');
 const { sendMessage } = require('../../utils/chat');
 
 const bot = require('../../bot');
@@ -13,9 +14,11 @@ const teamsCommand = ({ teamA, teamB }) => {
       return;
     }
 
-    const message = `🎲 *Team hiện tại* 🎲\n\n👤 *HOME:*\n${Array.from(
-      teamA.values()
-    ).join('\n')}\n\n👤 *AWAY:*\n${Array.from(teamB.values()).join('\n')}`;
+    const message = `🎲 *Team hiện tại* 🎲\n\n👤 *HOME:*\n${Array.from(teamA.values())
+      .map(getDisplayName)
+      .join('\n')}\n\n👤 *AWAY:*\n${Array.from(teamB.values())
+      .map(getDisplayName)
+      .join('\n')}`;
 
     sendMessage({
       msg,

--- a/src/utils/team-member.js
+++ b/src/utils/team-member.js
@@ -1,0 +1,49 @@
+/**
+ * Helpers for in-memory member/team entries.
+ *
+ * Identifier stability (for linking to registered players):
+ * - user_id (Telegram ID): Most stable. Assigned by Telegram, does not change
+ *   when the user changes display name or username. Use when available (/addme).
+ * - number (shirt number): Less stable. Can change if a player changes number.
+ * - name: Least stable. User can change first_name in Telegram anytime.
+ *
+ * We carry userId through the flow so match save can resolve by user_id first.
+ */
+
+/**
+ * @typedef {{ name: string, userId?: number }} MemberEntry
+ */
+
+/**
+ * Create an entry for members/team Maps. Supports optional Telegram user_id.
+ * @param {string} name - Display name
+ * @param {number} [userId] - Telegram user id (from msg.from.id), only set when from /addme
+ * @returns {MemberEntry}
+ */
+function toEntry(name, userId) {
+  return userId != null ? { name, userId } : { name };
+}
+
+/**
+ * Get display string from a member/team value (supports legacy string values).
+ * @param {string|MemberEntry} value
+ * @returns {string}
+ */
+function getDisplayName(value) {
+  return typeof value === 'string' ? value : value.name;
+}
+
+/**
+ * Get Telegram user id if present (only set for entries added via /addme).
+ * @param {string|MemberEntry} value
+ * @returns {number|undefined}
+ */
+function getUserId(value) {
+  return typeof value === 'string' ? undefined : value.userId;
+}
+
+module.exports = {
+  toEntry,
+  getDisplayName,
+  getUserId,
+};


### PR DESCRIPTION
Carry Telegram user_id through members/teams so /match SAVE links lineups to registered players by user_id first, falling back to exact name only, and keep unregistered names as display-only entries.

Made-with: Cursor