### PR TITLE
fix(admin): resolve build errors and Node.js version compatibility

### DIFF
--- a/admin/nixpacks.toml
+++ b/admin/nixpacks.toml
@@ -1,5 +1,5 @@
 [phases.setup]
-nixPkgs = ['nodejs_20', 'yarn']
+nixPkgs = ['nodejs_22', 'yarn']
 
 [phases.install]
 cmds = ['yarn install --frozen-lockfile']

--- a/admin/package.json
+++ b/admin/package.json
@@ -2,6 +2,9 @@
   "name": "chiateam-admin",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22.13.0"
+  },
   "scripts": {
     "dev": "next dev -p 8389",
     "build": "next build",


### PR DESCRIPTION
- Disable no-undef ESLint rule to fix false positives with React auto-imports and TypeScript global types
- Update nixpacks.toml to use Node.js 22 instead of Node.js 20
- Add engines field to package.json requiring Node.js >= 22.13.0 for eslint-visitor-keys compatibility